### PR TITLE
Reading and using joint encoders with 3rd USB board

### DIFF
--- a/include/DS0.h
+++ b/include/DS0.h
@@ -97,25 +97,27 @@ enum jointState{
  */
 struct DOF {
   u_16 type;
-  jointState state;            // is this DoF enabled?
-  s_24 enc_val;		// encoder value
-  s_16 current_cmd;	// DAC command to achieve tau at actuator
-  float jpos;		// actual DOF coordinate (rad)
+  jointState state;     // is this DoF enabled?
+  s_24 enc_val;			// encoder value
+  s_24 joint_enc_val;	// Joint encoder value
+  s_16 current_cmd;		// DAC command to achieve tau at actuator
+  float jpos;			// actual DOF coordinate (rad)
   float mpos;
   //  float jpos_old;       // previous DOF coordinate (rad)
   //  float mpos_old;
-  float jvel; 		// actual DOF velocity(q-dot)
+  float jvel; 			// actual DOF velocity(q-dot)
   float mvel;
-  float tau;		// actual DOF force/torque at joint
-  float tau_d;		// desired DOF force/torque at motor capstan after gearbox
-  float tau_g;		// Estimated gravity force/torque on joint.
-  float jpos_d;		// desired DOF coordinate (rad)
+  float tau;			// actual DOF force/torque at joint
+  float tau_d;			// desired DOF force/torque at motor capstan after gearbox
+  float tau_g;			// Estimated gravity force/torque on joint.
+  float jpos_d;			// desired DOF coordinate (rad)
   float mpos_d;
   float jpos_d_old;     // previous desired DOF coordinate (rad)
   float mpos_d_old;
-  float jvel_d;		// desired DOF velocity (q-dot-desired)
+  float jvel_d;			// desired DOF velocity (q-dot-desired)
   float mvel_d;
   int enc_offset;       // Encoder offset to "zero"
+  int joint_enc_offset; // Joint Encoder offset to "zero"
   float perror_int;     // integrated position error for joint space position control
 };
 

--- a/include/DS0.h
+++ b/include/DS0.h
@@ -102,6 +102,7 @@ struct DOF {
   s_24 joint_enc_val;	// Joint encoder value
   s_16 current_cmd;		// DAC command to achieve tau at actuator
   float jpos;			// actual DOF coordinate (rad)
+  float j_enc_pos;		// actual DOF coordinate of Joint encoder (rad)
   float mpos;
   //  float jpos_old;       // previous DOF coordinate (rad)
   //  float mpos_old;

--- a/include/raven/defines.h
+++ b/include/raven/defines.h
@@ -39,8 +39,8 @@
 
 //~~~~~~~~~ tool adapter definition ~~~~~~~~~~~~~~~~
 
-//#define RAVEN_TOOLS
-#define DV_ADAPTER			1
+#define RAVEN_TOOLS
+//#define DV_ADAPTER			1
 #define RICKS_TOOLS     //skips tool initialization
 //#define SCISSOR_RIGHT
 #define OPPOSE_GRIP
@@ -49,10 +49,10 @@
 //~~~~~~~~~ USB Board definition ~~~~~~~~~~~~~~~~~~~
 // Two arm identification
 // Change this to match device ID in /dev/brl_usbXX
-#define GREEN_ARM_SERIAL 37
-#define GOLD_ARM_SERIAL  29
+#define GREEN_ARM_SERIAL 10
+#define GOLD_ARM_SERIAL  25
 
-#define JOINT_ENC_SERIAL 46 	//99 if no joint encoder board
+#define JOINT_ENC_SERIAL 26 	//99 if no joint encoder board
 
 
 //~~~~~~~~ Other settings, experts only ~~~~~~~~~~~~
@@ -100,6 +100,13 @@
 
 #define ENC_CNT_PER_DEG (float)(ENC_CNTS_PER_REV / 360)
 #define ENC_CNT_PER_RAD (float)(ENC_CNTS_PER_REV / (2*M_PI))
+
+#define ROTARY_JOINT_ENC_PER_REV	2048 * 4
+#define LINEAR_JOINT_ENC_PER_M		200000 //maybe 800,000?
+
+#define JOINT_ENC_CNT_PER_DEG (float)(ENC_CNTS_PER_REV / 360)
+
+
 
 //Verbose mode
 //#define MORE_MESSAGES 1

--- a/include/raven/defines.h
+++ b/include/raven/defines.h
@@ -34,7 +34,7 @@
 #define SURGICAL_ROBOT     	1
 #define RAVEN_II        	1
 //#define KIST
-#define JOINT_ENCODERS		1 	// 1 indicates that there is a USB board for joint encoders
+#define JOINT_ENCODERS		0 	// 1 indicates that there is a USB board for joint encoders
 								// 0 if no joint encoders
 
 //~~~~~~~~~ tool adapter definition ~~~~~~~~~~~~~~~~
@@ -49,10 +49,10 @@
 //~~~~~~~~~ USB Board definition ~~~~~~~~~~~~~~~~~~~
 // Two arm identification
 // Change this to match device ID in /dev/brl_usbXX
-#define GREEN_ARM_SERIAL 10
-#define GOLD_ARM_SERIAL  25
+#define GREEN_ARM_SERIAL 27
+#define GOLD_ARM_SERIAL  24
 
-#define JOINT_ENC_SERIAL 26 	//99 if no joint encoder board
+#define JOINT_ENC_SERIAL 99 	//99 if no joint encoder board
 
 
 //~~~~~~~~ Other settings, experts only ~~~~~~~~~~~~

--- a/include/raven/defines.h
+++ b/include/raven/defines.h
@@ -56,7 +56,7 @@
 
 
 //~~~~~~~~ Other settings, experts only ~~~~~~~~~~~~
-//#define NO_LPF    // This setting short circuits the Low Pass Filter in state_estimate.cpp
+#define NO_LPF    // This setting short circuits the Low Pass Filter in state_estimate.cpp
 //#define OMNI_GAIN  2  // Get a little more oomph out of the omni grasping button - sets a gain in local__io.cpp
 //#define ORIENTATION_V
 

--- a/include/raven/defines.h
+++ b/include/raven/defines.h
@@ -34,12 +34,14 @@
 #define SURGICAL_ROBOT     	1
 #define RAVEN_II        	1
 //#define KIST
+#define JOINT_ENCODERS		1 	// 1 indicates that there is a USB board for joint encoders
+								// 0 if no joint encoders
 
 //~~~~~~~~~ tool adapter definition ~~~~~~~~~~~~~~~~
 
 //#define RAVEN_TOOLS
 #define DV_ADAPTER			1
-//#define RICKS_TOOLS     //skips tool initialization
+#define RICKS_TOOLS     //skips tool initialization
 //#define SCISSOR_RIGHT
 #define OPPOSE_GRIP
 
@@ -49,6 +51,8 @@
 // Change this to match device ID in /dev/brl_usbXX
 #define GREEN_ARM_SERIAL 37
 #define GOLD_ARM_SERIAL  29
+
+#define JOINT_ENC_SERIAL 46 	//99 if no joint encoder board
 
 
 //~~~~~~~~ Other settings, experts only ~~~~~~~~~~~~

--- a/include/raven/fwd_cable_coupling.h
+++ b/include/raven/fwd_cable_coupling.h
@@ -52,3 +52,5 @@ void fwdMechCableCoupling(mechanism *mech);
 
 void fwdTorqueCoupling(device *device0, int runlevel);
 void fwdMechTorqueCoupling(mechanism *mech);
+
+int fwdJointEncoders(device *device0);

--- a/include/raven/get_USB_packet.h
+++ b/include/raven/get_USB_packet.h
@@ -41,5 +41,8 @@
 //Function prototypes
 void initiateUSBGet(device *device0);
 int getUSBPackets(device *device0);
-int getUSBPacket(int id, mechanism *mech);
+
 void processEncoderPacket(mechanism *mech, unsigned char buffer[]);
+
+int getUSBPacket(int id, device *dev, int index);
+void processJointEncoderPacket(device* dev, unsigned char buffer[]);

--- a/include/raven/put_USB_packet.h
+++ b/include/raven/put_USB_packet.h
@@ -37,3 +37,4 @@
 //Function prototypes
 void putUSBPackets(device *device0);
 int putUSBPacket(int id, mechanism *mech);
+int putJointEncUSBPacket(int id);

--- a/src/raven/USB_init.cpp
+++ b/src/raven/USB_init.cpp
@@ -155,7 +155,7 @@ int USBInit(device *device0)
     vector<string> files = vector<string>();
     getdir(BRL_USB_DEV_DIR, files);
 	sort(files.begin(), files.end());
-reverse(files.begin(),files.end());
+	reverse(files.begin(),files.end());
 
     log_msg("  Found board files::");
     for (unsigned int i = 0;i < files.size();i++) {
@@ -171,7 +171,10 @@ reverse(files.begin(),files.end());
         boardStr = BRL_USB_DEV_DIR;
         boardStr += files[i];
         boardid = get_board_id_from_filename(files[i]);
-		if((boardid == GREEN_ARM_SERIAL) || (boardid == GOLD_ARM_SERIAL ))
+
+        // Is this a USB device that we know or care about?
+		if((boardid == GREEN_ARM_SERIAL) || (boardid == GOLD_ARM_SERIAL )
+				|| (boardid == JOINT_ENC_SERIAL ))
 		{
 
 	        // Open usb dev
@@ -208,6 +211,11 @@ reverse(files.begin(),files.end());
 	            device0->mech[mechcounter].type = GOLD_ARM;
 				mechcounter++;
 	        }
+	        else if (boardid == JOINT_ENC_SERIAL)
+	        {
+	            okboards++;
+	            log_msg("  Joint Encoder on board #%d.",boardid);
+	        }
 	        else
 	        {
 	            log_msg("*** WARNING: USB BOARD #%d NOT CONNECTED TO MECH (update defines?).",boardid);
@@ -230,10 +238,13 @@ reverse(files.begin(),files.end());
 
     if (okboards < 2){
         ROS_ERROR("Error: failed to init two boards!  Behavior is henceforce undetermined...");
-//        return 0;
     }
+//      return 0;
     //Only now we have info about number of boards and set it to number of mechanisms
-    NUM_MECH = USBBoards.activeAtStart;
+    //should this be the number of arms or number of USB boards
+    // lets try to do it as # arms
+    //JOINT_ENCODERS tag
+    NUM_MECH = mechcounter;//USBBoards.activeAtStart;
 
     return USBBoards.activeAtStart;
 }

--- a/src/raven/USB_init.cpp
+++ b/src/raven/USB_init.cpp
@@ -227,8 +227,6 @@ int USBInit(device *device0)
 	        boardFPs[boardid] = tmp_fileHandle;   // Map serial (i) to fileHandle (tmp_fileHandle)
 	        USBBoards.activeAtStart++;            // Increment board count
 
-	        log_msg("board FPs ---> %i", boardFPs[boardid]);
-
 
 	        if ( write_zeros_to_board(boardid) != 0){
 	            ROS_ERROR("Warning: failed initial board reset (set-to-zero)");

--- a/src/raven/console_process.cpp
+++ b/src/raven/console_process.cpp
@@ -386,7 +386,7 @@ void outputRobotState(){
         for (int i=0;i<MAX_DOF_PER_MECH;i++)
             cout<<fixed<<setprecision(3)<<DOF_types[j*MAX_DOF_PER_MECH+i].KD<<"\t";
         cout<<"\n";
-
+/*
         cout<<"jac force:\t";
         float forces[6];
         device0.mech[j].r2_jac.get_force(forces);
@@ -400,6 +400,14 @@ void outputRobotState(){
         for (int i=0; i < 6;i++)
             cout<<fixed<<"\t"<<setprecision(3)<<velocity[i];
         cout<<"\n";
+*/
+        if (JOINT_ENCODERS){
+        	cout<<"j_enc_val:\t";
+        	for (int i=0;i<MAX_DOF_PER_MECH/2;i++)
+        		cout<<device0.mech[j].joint[i].joint_enc_val<<"\t";
+        	cout<<"\n";
+        }
+
 //
 //        cout<<"enc_offset:\t";
 //        for (int i=0;i<MAX_DOF_PER_MECH;i++)

--- a/src/raven/console_process.cpp
+++ b/src/raven/console_process.cpp
@@ -18,23 +18,23 @@
  */
 
 /**
-*  	\file console_process.cpp
-*
-*	\brief Lets the user set different control modes and outputs data to the console periodically.
-*   	User can toggle to either specify joint torque, set control mode, or toggle console messages.
-*
-*  	\author Hawkeye King
-*
-* 	\fn These are the 3 functions in console_process.cpp file.
-*           Functions marked with "*" are called explicitly from other files.
-* 	       *(1) console_process	 	:uses (2)(3)
-*       	(2) getkey
-* 		(3) outputRobotState
-*
-*  	\date ??
-*
-*  	\ingroup IO
-*/
+ *  	\file console_process.cpp
+ *
+ *	\brief Lets the user set different control modes and outputs data to the console periodically.
+ *   	User can toggle to either specify joint torque, set control mode, or toggle console messages.
+ *
+ *  	\author Hawkeye King
+ *
+ * 	\fn These are the 3 functions in console_process.cpp file.
+ *           Functions marked with "*" are called explicitly from other files.
+ * 	       *(1) console_process	 	:uses (2)(3)
+ *       	(2) getkey
+ * 		(3) outputRobotState
+ *
+ *  	\date ??
+ *
+ *  	\ingroup IO
+ */
 
 #include <cstdio>
 #include <iomanip>
@@ -58,335 +58,335 @@ void outputRobotState();
 int getkey();
 
 /**
-*	\fn void *console_process(void *)
-*
-* 	\brief this thread is dedicated to console io
-*
-* 	\desc user sends commands via console where output messages are also displayed
-*
-* 	\param a pointer to void
-*
-*	\ingroup IO
-*
-*	\return void
-*/
+ *	\fn void *console_process(void *)
+ *
+ * 	\brief this thread is dedicated to console io
+ *
+ * 	\desc user sends commands via console where output messages are also displayed
+ *
+ * 	\param a pointer to void
+ *
+ *	\ingroup IO
+ *
+ *	\return void
+ */
 void *console_process(void *)
 {
-    ros::Time t1, t2;
-    ros::Duration d;
-    t1=t1.now();
-    t2=t2.now();
+	ros::Time t1, t2;
+	ros::Duration d;
+	t1=t1.now();
+	t2=t2.now();
 
-    //Low priority non realtime thread
-    sched_param param;                    // priority settings
-    param.sched_priority = 0;
-    if (sched_setscheduler(0, SCHED_OTHER, &param)==-1)
-    {
-        perror("sched_setscheduler failed for console process");
-        exit(-1);
-    }
+	//Low priority non realtime thread
+	sched_param param;                    // priority settings
+	param.sched_priority = 0;
+	if (sched_setscheduler(0, SCHED_OTHER, &param)==-1)
+	{
+		perror("sched_setscheduler failed for console process");
+		exit(-1);
+	}
 
-    int output_robot=false;
-    int theKey,print_msg=1;
-    char inputbuffer[100];
-    sleep(1);
-    // Run shell interaction
-    while (ros::ok())
-    {
-        // Output UI hints
-        if ( print_msg ){
-            log_msg("[[\t'C'  : toggle console messages ]]");
-            log_msg("[[\t'T'  : specify joint torque    ]]");
-            log_msg("[[\t'M'  : set control mode        ]]");
-            log_msg("[[\t'^C' : Quit                    ]]");
-            print_msg=0;
-        }
-        // Get UI command
-        theKey = getkey();
-        switch (theKey){
-            case 'z':
-            {
-                output_robot = 0;
-                setDofTorque(0,0,0);  /// only mech 0 dof 0 -> 0 torque??
-                log_msg("Torque zero'd");
-                print_msg=1;
-                break;
-            }
-            case 'd':
-	    case 'D':
-            {
-              log_msg("pedal down");
-              setSurgeonMode(1);
-              updateMasterRelativeOrigin(&device0);
-              break;
-            }
-            case 'u':
-	    case 'U':
-            {
-              log_msg("pedal up");
-              setSurgeonMode(0);
-              updateMasterRelativeOrigin(&device0);
-              break;
-            }
-            case 'e':
-            case 'E':
-            case '0':
-            {
-                output_robot = 0;
-                soft_estopped=TRUE;
-                print_msg=1;
-                log_msg("Soft estopped");
-                break;
-            }
-            case '+':
-            case '=':
-            {
-                soft_estopped=FALSE;
-                print_msg=1;
-                log_msg("Soft estop off");
-                break;
-            }
-            case 'c':
-            case 'C':
-            {
-                log_msg("Console output on:%d", output_robot);
-                output_robot = !output_robot;
-                print_msg=1;
-                break;
-            }
-            case 't':
-            case 'T':
-            {
-                print_msg=1;
-                // Get user-input mechanism #
-                printf("\n\nEnter a mechanism number: 0-Gold, 1-Green:\t");
-                cin.getline (inputbuffer,100);
-                unsigned int _mech = atoi(inputbuffer);
-                if ( _mech > 1 ) break;
+	int output_robot=false;
+	int theKey,print_msg=1;
+	char inputbuffer[100];
+	sleep(1);
+	// Run shell interaction
+	while (ros::ok())
+	{
+		// Output UI hints
+		if ( print_msg ){
+			log_msg("[[\t'C'  : toggle console messages ]]");
+			log_msg("[[\t'T'  : specify joint torque    ]]");
+			log_msg("[[\t'M'  : set control mode        ]]");
+			log_msg("[[\t'^C' : Quit                    ]]");
+			print_msg=0;
+		}
+		// Get UI command
+		theKey = getkey();
+		switch (theKey){
+		case 'z':
+		{
+			output_robot = 0;
+			setDofTorque(0,0,0);  /// only mech 0 dof 0 -> 0 torque??
+			log_msg("Torque zero'd");
+			print_msg=1;
+			break;
+		}
+		case 'd':
+		case 'D':
+		{
+			log_msg("pedal down");
+			setSurgeonMode(1);
+			updateMasterRelativeOrigin(&device0);
+			break;
+		}
+		case 'u':
+		case 'U':
+		{
+			log_msg("pedal up");
+			setSurgeonMode(0);
+			updateMasterRelativeOrigin(&device0);
+			break;
+		}
+		case 'e':
+		case 'E':
+		case '0':
+		{
+			output_robot = 0;
+			soft_estopped=TRUE;
+			print_msg=1;
+			log_msg("Soft estopped");
+			break;
+		}
+		case '+':
+		case '=':
+		{
+			soft_estopped=FALSE;
+			print_msg=1;
+			log_msg("Soft estop off");
+			break;
+		}
+		case 'c':
+		case 'C':
+		{
+			log_msg("Console output on:%d", output_robot);
+			output_robot = !output_robot;
+			print_msg=1;
+			break;
+		}
+		case 't':
+		case 'T':
+		{
+			print_msg=1;
+			// Get user-input mechanism #
+			printf("\n\nEnter a mechanism number: 0-Gold, 1-Green:\t");
+			cin.getline (inputbuffer,100);
+			unsigned int _mech = atoi(inputbuffer);
+			if ( _mech > 1 ) break;
 
-                // Get user-input joint #
-                printf("\nEnter a joint number: 0-shoulder, 1-elbow, 2-zins, 4-tool_rot, 5-wrist, 6/7- grasp 1/2:\t");
-                cin.getline (inputbuffer,100);
-                unsigned int _joint = atoi(inputbuffer);
-                if ( _joint > MAX_DOF_PER_MECH ) break;
+			// Get user-input joint #
+			printf("\nEnter a joint number: 0-shoulder, 1-elbow, 2-zins, 4-tool_rot, 5-wrist, 6/7- grasp 1/2:\t");
+			cin.getline (inputbuffer,100);
+			unsigned int _joint = atoi(inputbuffer);
+			if ( _joint > MAX_DOF_PER_MECH ) break;
 
-                // Get user-input DAC value #
-                printf("\nEnter a torque value in miliNewton-meters:\t");
-                cin.getline (inputbuffer,100);
-                int _torqueval = atoi(inputbuffer);
+			// Get user-input DAC value #
+			printf("\nEnter a torque value in miliNewton-meters:\t");
+			cin.getline (inputbuffer,100);
+			int _torqueval = atoi(inputbuffer);
 
-                log_msg("Commanded mech.joint (tau):%d.%d (%d))\n",_mech, _joint, _torqueval);
-                setDofTorque(_mech, _joint, _torqueval);
-                break;
-            }
-            case 'm':
-            case 'M':
-            {
-                // Get user-input DAC value #
-                printf("\n\nEnter new control mode: 0=NULL, 1=NULL, 2=joint_velocity, 3=apply_torque, 4=homing, 5=motor_pd, 6=cartesian_space_motion, 7=multi_dof_sinusoid \t");
-                cin.getline (inputbuffer,100);
-                t_controlmode _cmode = (t_controlmode)(atoi(inputbuffer));
-                log_msg("recieved control mode:%d\n\n",_cmode);
-                setRobotControlMode(_cmode);
-                print_msg=1;
-                break;
-            }
-        }
+			log_msg("Commanded mech.joint (tau):%d.%d (%d))\n",_mech, _joint, _torqueval);
+			setDofTorque(_mech, _joint, _torqueval);
+			break;
+		}
+		case 'm':
+		case 'M':
+		{
+			// Get user-input DAC value #
+			printf("\n\nEnter new control mode: 0=NULL, 1=NULL, 2=joint_velocity, 3=apply_torque, 4=homing, 5=motor_pd, 6=cartesian_space_motion, 7=multi_dof_sinusoid \t");
+			cin.getline (inputbuffer,100);
+			t_controlmode _cmode = (t_controlmode)(atoi(inputbuffer));
+			log_msg("recieved control mode:%d\n\n",_cmode);
+			setRobotControlMode(_cmode);
+			print_msg=1;
+			break;
+		}
+		}
 
-        // Output the robot state once/sec
-        if ( output_robot        &&
-             (t1.now()-t1).toSec() > 1 )
-        {
-            outputRobotState();
-            t1=t1.now();
-        }
+		// Output the robot state once/sec
+		if ( output_robot        &&
+				(t1.now()-t1).toSec() > 1 )
+		{
+			outputRobotState();
+			t1=t1.now();
+		}
 
-        usleep(33*1e3); //Sleep for 1/30 seconds
+		usleep(33*1e3); //Sleep for 1/30 seconds
 
 		// Output log messages
 		while (msgqueue.size() > 0){
-		  char* buf = msgqueue.front();
-		  //std::cout << "buf\n" << buf << std::endl;
-		  ROS_INFO("%s", buf);
-		  msgqueue.pop();
-		  free(buf);
+			char* buf = msgqueue.front();
+			//std::cout << "buf\n" << buf << std::endl;
+			ROS_INFO("%s", buf);
+			msgqueue.pop();
+			free(buf);
 		}
 
-    }
+	}
 
-    return(NULL);
+	return(NULL);
 }
 
 /**
-*	\fn int getkey()
-*
-*	\brief gets keyboard character for switch case's of console_process()
-*
-* 	\return returns keyboard character
-*
-*	\ingroup IO
-*
-*	\return character int
-*/
+ *	\fn int getkey()
+ *
+ *	\brief gets keyboard character for switch case's of console_process()
+ *
+ * 	\return returns keyboard character
+ *
+ *	\ingroup IO
+ *
+ *	\return character int
+ */
 int getkey() {
-    int character;
-    termios orig_term_attr;
-    termios new_term_attr;
+	int character;
+	termios orig_term_attr;
+	termios new_term_attr;
 
-    /* set the terminal to raw mode */
-    tcgetattr(fileno(stdin), &orig_term_attr);
-    memcpy(&new_term_attr, &orig_term_attr, sizeof(termios));
-    new_term_attr.c_lflag &= ~(ECHO|ICANON);
-    new_term_attr.c_cc[VTIME] = 0;
-    new_term_attr.c_cc[VMIN] = 0;
-    tcsetattr(fileno(stdin), TCSANOW, &new_term_attr);
+	/* set the terminal to raw mode */
+	tcgetattr(fileno(stdin), &orig_term_attr);
+	memcpy(&new_term_attr, &orig_term_attr, sizeof(termios));
+	new_term_attr.c_lflag &= ~(ECHO|ICANON);
+	new_term_attr.c_cc[VTIME] = 0;
+	new_term_attr.c_cc[VMIN] = 0;
+	tcsetattr(fileno(stdin), TCSANOW, &new_term_attr);
 
-    /* read a character from the stdin stream without blocking */
-    /*   returns EOF (-1) if no character is available */
-    character = fgetc(stdin);
+	/* read a character from the stdin stream without blocking */
+	/*   returns EOF (-1) if no character is available */
+	character = fgetc(stdin);
 
-    /* restore the original terminal attributes */
-    tcsetattr(fileno(stdin), TCSANOW, &orig_term_attr);
+	/* restore the original terminal attributes */
+	tcsetattr(fileno(stdin), TCSANOW, &orig_term_attr);
 
-    return character;
+	return character;
 }
 
 /**
-*	\fn void outputRobotState()
-*
-*	\brief prints out all the robot's states on the console window
-*
-*	\ingroup IO
-*
-*	\return void
-*/
+ *	\fn void outputRobotState()
+ *
+ *	\brief prints out all the robot's states on the console window
+ *
+ *	\ingroup IO
+ *
+ *	\return void
+ */
 void outputRobotState(){
-    cout<<"Runlevel: "<< static_cast<unsigned short int>(device0.runlevel)<<"\n";
-    for (int j = 0; j < 2; j++)
-    {
-        if (device0.mech[j].type == GOLD_ARM)
-            cout << "Gold arm:\t";
-        else if (device0.mech[j].type == GREEN_ARM)
-            cout << "Green arm:\t";
-        else
-            cout << "Unknown arm:\t";
+	cout<<"Runlevel: "<< static_cast<unsigned short int>(device0.runlevel)<<"\n";
+	for (int j = 0; j < 2; j++)
+	{
+		if (device0.mech[j].type == GOLD_ARM)
+			cout << "Gold arm:\t";
+		else if (device0.mech[j].type == GREEN_ARM)
+			cout << "Green arm:\t";
+		else
+			cout << "Unknown arm:\t";
 
-        cout<<"Board "<<j<<", type "<<device0.mech[j].type << ":\n";
-        cout<<"P: (x,y,z) : ("<< device0.mech[j].pos.x / (1000.0*1000.0) << "\t" << device0.mech[j].pos.y / (1000.0*1000.0);
-        cout << "\t" << device0.mech[j].pos.z / (1000.0*1000.0);
-        cout << ") :\t";
-        cout<<"PD: (x,y,z) : ("<< device0.mech[j].pos_d.x / (1000.0*1000.0) << "\t" << device0.mech[j].pos_d.y / (1000.0*1000.0);
-        cout << "\t" << device0.mech[j].pos_d.z / (1000.0*1000.0);
-        cout << ") :\t";
-        cout << " Grasp/d:" << (double)device0.mech[j].ori.grasp/1000.0 << "/" << (double)device0.mech[j].ori_d.grasp / 1000.0 << "\n";
-//
-//        cout<<"pos:\t";
-//        cout<<device0.mech[j].pos.x<<"\t";
-//        cout<<device0.mech[j].pos.y<<"\t";
-//        cout<<device0.mech[j].pos.z<<"\n";
-//
-//        cout<<"pos_d:\t";
-//        cout<<device0.mech[j].pos_d.x<<"\t";
-//        cout<<device0.mech[j].pos_d.y<<"\t";
-//        cout<<device0.mech[j].pos_d.z<<"\n";
+		cout<<"Board "<<j<<", type "<<device0.mech[j].type << ":\n";
+		cout<<"P: (x,y,z) : ("<< device0.mech[j].pos.x / (1000.0*1000.0) << "\t" << device0.mech[j].pos.y / (1000.0*1000.0);
+		cout << "\t" << device0.mech[j].pos.z / (1000.0*1000.0);
+		cout << ") :\t";
+		cout<<"PD: (x,y,z) : ("<< device0.mech[j].pos_d.x / (1000.0*1000.0) << "\t" << device0.mech[j].pos_d.y / (1000.0*1000.0);
+		cout << "\t" << device0.mech[j].pos_d.z / (1000.0*1000.0);
+		cout << ") :\t";
+		cout << " Grasp/d:" << (double)device0.mech[j].ori.grasp/1000.0 << "/" << (double)device0.mech[j].ori_d.grasp / 1000.0 << "\n";
+		//
+		//        cout<<"pos:\t";
+		//        cout<<device0.mech[j].pos.x<<"\t";
+		//        cout<<device0.mech[j].pos.y<<"\t";
+		//        cout<<device0.mech[j].pos.z<<"\n";
+		//
+		//        cout<<"pos_d:\t";
+		//        cout<<device0.mech[j].pos_d.x<<"\t";
+		//        cout<<device0.mech[j].pos_d.y<<"\t";
+		//        cout<<device0.mech[j].pos_d.z<<"\n";
 
-        cout<<"type:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<device0.mech[j].joint[i].type<<"\t";
-        cout<<"\n";
+		cout<<"type:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<device0.mech[j].joint[i].type<<"\t";
+		cout<<"\n";
 
-        cout<<"enc_val:\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<device0.mech[j].joint[i].enc_val<<"\t";
-        cout<<"\n";
+		cout<<"enc_val:\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<device0.mech[j].joint[i].enc_val<<"\t";
+		cout<<"\n";
 
-        cout<<"enc_off:\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<device0.mech[j].joint[i].enc_offset<<"\t";
-        cout<<"\n";
+		cout<<"enc_off:\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<device0.mech[j].joint[i].enc_offset<<"\t";
+		cout<<"\n";
 
-        cout<<"mpos:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].mpos <<"\t";
-        cout<<"\n";
+		cout<<"mpos:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].mpos <<"\t";
+		cout<<"\n";
 
-        cout<<"mpos_d:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].mpos_d <<"\t";
-        cout<<"\n";
+		cout<<"mpos_d:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].mpos_d <<"\t";
+		cout<<"\n";
 
-        cout<<"mvel:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(0)<<device0.mech[j].joint[i].mvel <<"\t";
-        cout<<"\n";
+		cout<<"mvel:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(0)<<device0.mech[j].joint[i].mvel <<"\t";
+		cout<<"\n";
 
-        cout<<"mvel_d:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(0)<<device0.mech[j].joint[i].mvel_d <<"\t";
-        cout<<"\n";
+		cout<<"mvel_d:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(0)<<device0.mech[j].joint[i].mvel_d <<"\t";
+		cout<<"\n";
 
-        cout<<"jpos:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            if (i!=2)
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos <<"\t";
-            else
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos<<"\t";
-        cout<<"\n";
+		cout<<"jpos:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			if (i!=2)
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos <<"\t";
+			else
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos<<"\t";
+		cout<<"\n";
 
-        cout<<"jpos_d:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            if (i!=2)
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos_d <<"\t";
-            else
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos_d<<"\t";
-        cout<<"\n";
+		cout<<"jpos_d:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			if (i!=2)
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos_d <<"\t";
+			else
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jpos_d<<"\t";
+		cout<<"\n";
 
-        cout<<"jvel:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            if (i!=2)
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jvel <<"\t";
-            else
-                cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jvel<<"\t";
-        cout<<"\n";
+		cout<<"jvel:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			if (i!=2)
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jvel <<"\t";
+			else
+				cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].jvel<<"\t";
+		cout<<"\n";
 
-        cout<<"jvel_d:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            if (i!=2)
-                cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].jvel_d <<"\t";
-            else
-                cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].jvel_d<<"\t";
-        cout<<"\n";
+		cout<<"jvel_d:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			if (i!=2)
+				cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].jvel_d <<"\t";
+			else
+				cout<<fixed<<setprecision(2)<<device0.mech[j].joint[i].jvel_d<<"\t";
+		cout<<"\n";
 
-        cout<<"tau_d:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau_d<<"\t";
-        cout<<"\n";
+		cout<<"tau_d:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau_d<<"\t";
+		cout<<"\n";
 
-        cout<<"tau:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau<<"\t";
-        cout<<"\n";
+		cout<<"tau:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau<<"\t";
+		cout<<"\n";
 
-        cout<<"tau_g:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau_g<<"\t";
-        cout<<"\n";
+		cout<<"tau_g:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].tau_g<<"\t";
+		cout<<"\n";
 
-        cout<<"DAC:\t\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].current_cmd<<"\t";
-        cout<<"\n";
+		cout<<"DAC:\t\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<device0.mech[j].joint[i].current_cmd<<"\t";
+		cout<<"\n";
 
-        cout<<"KP gains:\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<DOF_types[j*MAX_DOF_PER_MECH+i].KP<<"\t";
-        cout<<"\n";
+		cout<<"KP gains:\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<DOF_types[j*MAX_DOF_PER_MECH+i].KP<<"\t";
+		cout<<"\n";
 
-        cout<<"KD gains:\t";
-        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-            cout<<fixed<<setprecision(3)<<DOF_types[j*MAX_DOF_PER_MECH+i].KD<<"\t";
-        cout<<"\n";
-/*
+		cout<<"KD gains:\t";
+		for (int i=0;i<MAX_DOF_PER_MECH;i++)
+			cout<<fixed<<setprecision(3)<<DOF_types[j*MAX_DOF_PER_MECH+i].KD<<"\t";
+		cout<<"\n";
+		/*
         cout<<"jac force:\t";
         float forces[6];
         device0.mech[j].r2_jac.get_force(forces);
@@ -400,21 +400,31 @@ void outputRobotState(){
         for (int i=0; i < 6;i++)
             cout<<fixed<<"\t"<<setprecision(3)<<velocity[i];
         cout<<"\n";
-*/
-        if (JOINT_ENCODERS){
-        	cout<<"j_enc_val:\t";
-        	for (int i=0;i<MAX_DOF_PER_MECH/2;i++)
-        		cout<<device0.mech[j].joint[i].joint_enc_val<<"\t";
-        	cout<<"\n";
-        }
+		 */
 
-//
-//        cout<<"enc_offset:\t";
-//        for (int i=0;i<MAX_DOF_PER_MECH;i++)
-//            cout<<device0.mech[j].joint[i].enc_offset<<"\t";
-//        cout<<"\n";
+			cout<<"j_enc_val:\t";
+			for (int i=0;i<MAX_DOF_PER_MECH/2;i++)
+				cout<<device0.mech[j].joint[i].joint_enc_val<<"\t";
+			cout<<"\n";
 
-        cout<<"\n";
-    }
+			cout<<"j_enc_off:\t";
+			for (int i=0;i<MAX_DOF_PER_MECH/2;i++)
+				cout<<device0.mech[j].joint[i].joint_enc_offset<<"\t";
+			cout<<"\n";
+
+			cout<<"j_enc_pos:\t";
+			for (int i=0;i<MAX_DOF_PER_MECH/2;i++)
+				cout<<device0.mech[j].joint[i].j_enc_pos<<"\t";
+			cout<<"\n";
+
+
+		//
+		//        cout<<"enc_offset:\t";
+		//        for (int i=0;i<MAX_DOF_PER_MECH;i++)
+		//            cout<<device0.mech[j].joint[i].enc_offset<<"\t";
+		//        cout<<"\n";
+
+		cout<<"\n";
+	}
 }
 

--- a/src/raven/get_USB_packet.cpp
+++ b/src/raven/get_USB_packet.cpp
@@ -17,8 +17,8 @@
  * along with Raven 2 Control.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /**\file get_USB_packet.cpp
-  *
+/**\file get_USB_packet.cpp
+ *
  * 	\brief 	contains functions for initializing the robot
  * 		intializes the DOF structure AND runs initialization routine
  *
@@ -32,38 +32,39 @@
  * 	\author Kenneth Fodero
  *
  * 	\date 2005
-*/
+ */
 
 
 #include "get_USB_packet.h"
 
 extern unsigned long int gTime;
 extern USBStruct USBBoards;
+extern int NUM_MECH;
 
 /**\fn void initiateUSBGet(device *device0)
   \brief Initiate data request from USB Board. Must be called before read
   \struct device
   \param device0 pointer to device struct
-*/
+ */
 
 void initiateUSBGet(device *device0)
 {
-  int i;
-  int err=0;
+	int i;
+	int err=0;
 
-  //Loop through all USB Boards
-  for (i = 0; i < USBBoards.activeAtStart; i++)
-    {
+	//Loop through all USB Boards
+	for (i = 0; i < USBBoards.activeAtStart; i++)
+	{
 
-	  err = startUSBRead( USBBoards.boards[i] );
-      if ( err < 0)
-        {
-		  //log_msg("Error (%d) initiating USB read %d on loop %d!", err, USBBoards.boards[i], gTime);
-        }
+		err = startUSBRead( USBBoards.boards[i] );
+		if ( err < 0)
+		{
+			log_msg("Error (%d) initiating USB read %d on loop %d!", err, USBBoards.boards[i], gTime);
+		}
 
 
 
-    }
+	}
 
 }
 
@@ -73,97 +74,157 @@ void initiateUSBGet(device *device0)
   \struct device
   \param device0 pointer to device struct
   \return zero on success and negative on failure
-*/
+ */
 
 int getUSBPackets(device *device0)
 {
-    int ret = 0;
+	int ret = 0;
+	int mech_index = 0;
 
-    //Loop through all USB Boards
-    for (int i = 0; i < USBBoards.activeAtStart; i++)
-    {
-        int err = getUSBPacket(
-			   USBBoards.boards[i],
-			   &(device0->mech[i] )
-			    );
-	if (err == -EBUSY || ret == -EBUSY)
-	  ret = -EBUSY;
+	//Loop through all USB Boards
+	for (int i = 0; i < USBBoards.activeAtStart; i++)
+	{
+		if (mech_index > NUM_MECH){
+			log_msg("USB/Mech index error");
+			return -1;
+		}
 
-        else if ( err < 0 )
-        {
-	  ret = err;
-        }
-    }
+		int err = getUSBPacket(USBBoards.boards[i], device0, mech_index);
 
-    return ret;
+		//only increment mech index if a mechanism board was processed
+		if (USBBoards.boards[i] != JOINT_ENC_SERIAL)
+			mech_index++;
+
+		if (err == -EBUSY || ret == -EBUSY)
+			ret = -EBUSY;
+
+		else if ( err < 0 )
+		{
+			ret = err;
+		}
+	}
+
+	return ret;
 }
 
 /**\fn int getUSBPacket(int id, mechanism *mech)
   \brief Takes data from a USB packet and uses it to fill the
  *   DS0 data structure
   \struct mechanism the data structure to fill
-  \param mech pointer to mechanism struct
-  \param id the USB board to read from
+  \param device	pointer to device struct
+  \param id 	the USB board to read from
+  \param index	the mechanism index associated with the board
+  	  	  	  	unless it's a joint encoder USB, which is associated
+  	  	  	  	with several mechanisms
   \return zero on success and negative on failure
-*/
+ */
 
-int getUSBPacket(int id, mechanism *mech)
+int getUSBPacket(int id, device *dev, int index)
 {
-    int result, type;
-    unsigned char buffer[MAX_IN_LENGTH];
+	int result, type;
+	unsigned char buffer[MAX_IN_LENGTH];
 
-    //Read USB Packet
-    result = usb_read(id,buffer,IN_LENGTH);
+	char joint_enc = (id == JOINT_ENC_SERIAL) ? 1 : 0;
 
-    // -- Check for read errors --
-    if (result < 0){
-      return result;
-    }
+	//Read USB Packet
+	result = usb_read(id,buffer, IN_LENGTH);
 
-    // No data or something. Boo.
-    else if ((result == 0) || (result != IN_LENGTH))
-      return -EIO;
+	// -- Check for read errors --
+	if (result < 0){
+		return result;
+	}
 
-    // -- Good packet so process it --
-    type = buffer[0];
+	// No data or something. Boo.
+	else if ((result == 0) || (result != IN_LENGTH))
+		return -EIO;
 
-    //Load in the data from the USB packet
-    switch (type)
-      {
-        //Handle and Encoder USB packet
-      case ENC:
-        processEncoderPacket(mech, buffer);
-        break;
-      }
+	// -- Good packet so process it --
+	type = buffer[0];
 
-    return 0;
+	//Load in the data from the USB packet
+	switch (type)
+	{
+	//Handle and Encoder USB packet
+	case ENC:
+		if (!joint_enc) processEncoderPacket(&(dev->mech[index]), buffer);
+		else if (joint_enc) processJointEncoderPacket(dev, buffer);
+		break;
+	}
+
+	return 0;
 }
 
 /**\fn void processEncoderPacket(mechanism* mech, unsigned char buffer[])
   \struct mechanism the data structure to fill
   \param mech pointer to mechanism struct
   \param buffer
-*/
+ */
 void processEncoderPacket(mechanism* mech, unsigned char buffer[])
 {
-    int i, numChannels;
-    int encVal;
+	int i, numChannels;
+	int encVal;
 
-    //Determine channels of data received
-    numChannels = buffer[1];
+	//Determine channels of data received
+	numChannels = buffer[1];
 
-    //Get the input pin status
+	//Get the input pin status
 #ifdef RAVEN_I
-    mech->inputs = ~buffer[2];
+	mech->inputs = ~buffer[2];
 #else
-    mech->inputs = buffer[2];
+	mech->inputs = buffer[2];
 #endif
 
-    //Loop through and read data for each channel
-    for (i = 0; i < numChannels; i++)
-    {
-        //Load encoder values
-        encVal = processEncVal(buffer, i);
-        mech->joint[i].enc_val = encVal;
-    }
+	//Loop through and read data for each channel
+	for (i = 0; i < numChannels; i++)
+	{
+		//Load encoder values
+		encVal = processEncVal(buffer, i);
+		mech->joint[i].enc_val = encVal;
+	}
+
+	return;
+}
+
+/**\fn void processJointEncoderPacket(device* dev, unsigned char buffer[])
+  \param device		device data structure, joint encoder data will be placed in
+  	  	  	  	  	each mechanism of device
+  \param buffer		the USB buffer to parse
+ */
+void processJointEncoderPacket(device* dev, unsigned char buffer[]){
+	int i, numChannels;
+	int encVal;
+	mechanism* mech_gold;
+	mechanism* mech_green;
+
+	//Determine channels of data received
+	numChannels = buffer[1];
+
+	//assume that joint encoder boards don't have PLC inputs
+	for (i = 0; i < NUM_MECH; i++){
+		if (dev->mech[i].type==GOLD_ARM){
+			mech_gold = &(dev->mech[i]);
+		}
+		else if (dev->mech[i].type==GREEN_ARM){
+			mech_green = &(dev->mech[i]);
+		}
+
+	}
+
+	//Loop through and read data for each channel
+	//place the values in the appropriate mechanism
+	for (i = 0; i < numChannels/2; i++)
+	{
+		//Load encoder values
+		encVal = processEncVal(buffer, i);
+		mech_gold->joint[i].joint_enc_val = encVal;
+	}
+
+	for (i = 0; i < numChannels/2; i++)
+	{
+		//Load green encoder values (4-7) into mech joints 0-3
+		encVal = processEncVal(buffer, i+numChannels/2);
+		mech_green->joint[i].joint_enc_val = encVal;
+	}
+
+	return;
 }

--- a/src/raven/globals.cpp
+++ b/src/raven/globals.cpp
@@ -39,8 +39,8 @@ DOF_type DOF_types[MAX_MECH*MAX_DOF_PER_MECH];
 USBStruct USBBoards;
 
 //tool gold_arm_tool (bipolar_forceps, GOLD_ARM);
-tool gold_arm_tool(large_needle, GOLD_ARM);
-//tool gold_arm_tool(r_grasper, GOLD_ARM);
+//tool gold_arm_tool(large_needle, GOLD_ARM);
+tool gold_arm_tool(r_grasper, GOLD_ARM);
 //tool gold_arm_tool(micro_forceps, GOLD_ARM);
 
 //#ifdef SCISSOR_RIGHT
@@ -51,6 +51,6 @@ tool gold_arm_tool(large_needle, GOLD_ARM);
 
 //tool green_arm_tool(mopocu_scissor, GREEN_ARM);
 //tool green_arm_tool(potts_scissor, GREEN_ARM);
-//tool green_arm_tool(r_grasper, GREEN_ARM);
-tool green_arm_tool(bipolar_forceps, GREEN_ARM);
+tool green_arm_tool(r_grasper, GREEN_ARM);
+//tool green_arm_tool(bipolar_forceps, GREEN_ARM);
 

--- a/src/raven/homing.cpp
+++ b/src/raven/homing.cpp
@@ -19,31 +19,31 @@
 
 
 /**
-*   \file homing.cpp
-*
-*	\brief Based on concept by UCSC, a procedure is implemented for joint position
-*			 discovery from incremental encoders.
-*
-*	\desc raven_homing called 1000 times per sec during INIT mode. Moves joints
-* 			to their limits (hard stop indicated by increased current) and then
-*			to their predefined "home" position.
-*
-*	\fn These are the 5 functions in homing.cpp file.
-*           Functions marked with "*" are called explicitly from other files.
-* 	       *(1) raven_homing	 	:uses (2)(3)(4)(5), utils.cpp (2)(3)(4)(6), inv_cable_coupling.cpp (1),
-*                                                     trajectory.cpp (3), t_to_DAC_val.cpp (1), pid_control.cpp (1)(2)
-*       	(2) set_joints_known_pos	:uses (2)(3)(4)(5), utils.cpp (3)(4), state_estimate.cpp (2)(3),
-*                                                     inv_cable_coupling.cpp (1), fwd_cable_coupling.cpp (2)
-* 		(3) homing(joint)		:uses trajectory.cpp (1)(2)(7)(8)
-* 		(4) homing(joint,tool)
-* 		(5) check_homing_condition
-*
-*	\author Hawkeye King
-*
-*       \date 3-Nov-2011
-*
-*	\ingroup Control
-*/
+ *   \file homing.cpp
+ *
+ *	\brief Based on concept by UCSC, a procedure is implemented for joint position
+ *			 discovery from incremental encoders.
+ *
+ *	\desc raven_homing called 1000 times per sec during INIT mode. Moves joints
+ * 			to their limits (hard stop indicated by increased current) and then
+ *			to their predefined "home" position.
+ *
+ *	\fn These are the 5 functions in homing.cpp file.
+ *           Functions marked with "*" are called explicitly from other files.
+ * 	       *(1) raven_homing	 	:uses (2)(3)(4)(5), utils.cpp (2)(3)(4)(6), inv_cable_coupling.cpp (1),
+ *                                                     trajectory.cpp (3), t_to_DAC_val.cpp (1), pid_control.cpp (1)(2)
+ *       	(2) set_joints_known_pos	:uses (2)(3)(4)(5), utils.cpp (3)(4), state_estimate.cpp (2)(3),
+ *                                                     inv_cable_coupling.cpp (1), fwd_cable_coupling.cpp (2)
+ * 		(3) homing(joint)		:uses trajectory.cpp (1)(2)(7)(8)
+ * 		(4) homing(joint,tool)
+ * 		(5) check_homing_condition
+ *
+ *	\author Hawkeye King
+ *
+ *       \date 3-Nov-2011
+ *
+ *	\ingroup Control
+ */
 
 #include <cstdlib>
 
@@ -68,198 +68,200 @@ extern DOF_type DOF_types[];
 
 
 /**
-*   \fn int raven_homing(device *device0, param_pass *currParams, int begin_homing)
-*
-*	\brief Move to hard stops in controlled way, "zero" the joint value, and then move to "home" position
-*
-*	\desc This function is called 1000 times per second during INIT mode
-*		This function operates in two phases:
-*    -# Discover joint position by running to hard stop. Using PD control (I term zero'd) we move the
-*           joint at a smooth rate until current increases which indicates hitting hard mechanical stop.
-*    -# Move joints to "home" position.  In this phase the robot moves from the joint limits to a
-*			designated pose in the center of the workspace.
-*
-*  	\param device0           Which  (top level) device to home (usually only one device per system)
-*   \param currParams        Current parameters (for Run Level)
-*   \param begin_homing      Flag to start the homing process
-*
-*   \ingroup Control
-*
-*	\return 0
-*
-*   \todo   Homing limits should be Amps not DAC units (see homing()).
-*/
+ *   \fn int raven_homing(device *device0, param_pass *currParams, int begin_homing)
+ *
+ *	\brief Move to hard stops in controlled way, "zero" the joint value, and then move to "home" position
+ *
+ *	\desc This function is called 1000 times per second during INIT mode
+ *		This function operates in two phases:
+ *    -# Discover joint position by running to hard stop. Using PD control (I term zero'd) we move the
+ *           joint at a smooth rate until current increases which indicates hitting hard mechanical stop.
+ *    -# Move joints to "home" position.  In this phase the robot moves from the joint limits to a
+ *			designated pose in the center of the workspace.
+ *
+ *  	\param device0           Which  (top level) device to home (usually only one device per system)
+ *   \param currParams        Current parameters (for Run Level)
+ *   \param begin_homing      Flag to start the homing process
+ *
+ *   \ingroup Control
+ *
+ *	\return 0
+ *
+ *   \todo   Homing limits should be Amps not DAC units (see homing()).
+ */
 int raven_homing(device *device0, param_pass *currParams, int begin_homing)
 {
-    static int homing_inited = 0;
-    static unsigned long int delay, delay2;
-    DOF *_joint = NULL;
-    mechanism* _mech = NULL;
-    int i=0,j=0;
+	static int homing_inited = 0;
+	static unsigned long int delay, delay2;
+	DOF *_joint = NULL;
+	mechanism* _mech = NULL;
+	int i=0,j=0;
 
 #ifdef RICKS_TOOLS      // Refers to Enders Game Prop manager!!
-                        //  these were wooden dummy tools for the movie.
-    _mech = NULL;  _joint = NULL;
+	//  these were wooden dummy tools for the movie.
+	_mech = NULL;  _joint = NULL;
 
-    while (loop_over_joints(device0, _mech, _joint, i,j) )
-    {
-       if (is_toolDOF(_joint))
-         {
-    	   _joint->state = jstate_ready;
-        }
-    }
+	while (loop_over_joints(device0, _mech, _joint, i,j) )
+	{
+		if (is_toolDOF(_joint))
+		{
+			_joint->state = jstate_ready;
+		}
+	}
 #endif
 
 
-    // Only run in init mode
-    if ( ! (currParams->runlevel == RL_INIT && currParams->sublevel == SL_AUTO_INIT ))
-    {
-        homing_inited = 0;
-        delay = gTime;
-        return 0;           // return if we are in the WRONG run level (PLC state)
-    }
+// Only run in init mode
+	if ( ! (currParams->runlevel == RL_INIT && currParams->sublevel == SL_AUTO_INIT ))
+	{
+		homing_inited = 0;
+		delay = gTime;
+		return 0;           // return if we are in the WRONG run level (PLC state)
+	}
 
-    // Wait a short time for amps to turn on
-    if (gTime - delay < 1000)
-    {
-        return 0;
-    }
-    // Initialize the homing sequence.
-    if (begin_homing || !homing_inited)     // only do this the first time through
-    {
-        // Zero out joint torques, and control inputs. Set joint.state=not_ready.
-        _mech = NULL;  _joint = NULL;
-        while (loop_over_joints(device0, _mech, _joint, i,j) )  // foreach (joint)
-        {
-            _joint->tau_d  = 0;
-            _joint->mpos_d = _joint->mpos;
-            _joint->jpos_d = _joint->jpos;
-            _joint->jvel_d = 0;
-            _joint->state  = jstate_not_ready;
+	// Wait a short time for amps to turn on
+	if (gTime - delay < 1000)
+	{
+		return 0;
+	}
+	// Initialize the homing sequence.
+	if (begin_homing || !homing_inited)     // only do this the first time through
+	{
+		// Zero out joint torques, and control inputs. Set joint.state=not_ready.
+		_mech = NULL;  _joint = NULL;
+		while (loop_over_joints(device0, _mech, _joint, i,j) )  // foreach (joint)
+		{
+			_joint->tau_d  = 0;
+			_joint->mpos_d = _joint->mpos;
+			_joint->jpos_d = _joint->jpos;
+			_joint->jvel_d = 0;
+			_joint->state  = jstate_not_ready;
 
-            if (is_toolDOF(_joint))
-                jvel_PI_control(_joint, 1);  // reset PI control integral term
-            homing_inited = 1;
-        }
-        log_msg("Homing sequence initialized");
-    }
+			if (is_toolDOF(_joint))
+				jvel_PI_control(_joint, 1);  // reset PI control integral term
+			homing_inited = 1;
+		}
+		log_msg("Homing sequence initialized");
+	}
 
-    // Specify motion commands
-    _mech = NULL;  _joint = NULL;
-    while ( loop_over_joints(device0, _mech, _joint, i,j) )
-    {
-        // Initialize tools first.
-        if ( is_toolDOF(_joint)){
-            homing(_joint, device0->mech[i].mech_tool);
+	// Specify motion commands
+	_mech = NULL;  _joint = NULL;
+	while ( loop_over_joints(device0, _mech, _joint, i,j) )
+	{
+		// Initialize tools first.
+		if ( is_toolDOF(_joint)){
+			homing(_joint, device0->mech[i].mech_tool);
 
-        }
-        else if(tools_ready( &(device0->mech[i]))){
-        	homing(_joint);
-        }
-    }
+		}
+		else if(tools_ready( &(device0->mech[i]))){
+			homing(_joint);
+		}
+	}
 
-    //Inverse Cable Coupling
-    invCableCoupling(device0, currParams->runlevel);
+	//Inverse Cable Coupling
+	invCableCoupling(device0, currParams->runlevel);
 
-    // Do PD control on all joints
-    _mech = NULL;  _joint = NULL;
-    while ( loop_over_joints(device0, _mech, _joint, i,j) )
-    {
-        mpos_PD_control( _joint );
-    }
+	// Do PD control on all joints
+	_mech = NULL;  _joint = NULL;
+	while ( loop_over_joints(device0, _mech, _joint, i,j) )
+	{
+		mpos_PD_control( _joint );
+	}
 
-    // Calculate output DAC values
-    TorqueToDAC(device0);
+	// Calculate output DAC values
+	TorqueToDAC(device0);
 
-    // Check homing conditions and set joint angles appropriately.
-    _mech = NULL;  _joint = NULL;
-    while ( loop_over_joints(device0, _mech, _joint, i,j) )
-    {
-        DOF * _joint =  &(_mech->joint[j]); ///\todo is this line necessary?
+	// Check homing conditions and set joint angles appropriately.
+	_mech = NULL;  _joint = NULL;
+	while ( loop_over_joints(device0, _mech, _joint, i,j) )
+	{
+		DOF * _joint =  &(_mech->joint[j]); ///\todo is this line necessary?
 
-        // Check to see if we've reached the joint limit.
-        if( check_homing_condition(_joint) )
-        {
-            log_msg("Found limit on joint %d cmd: %d \t", _joint->type, _joint->current_cmd, DOF_types[_joint->type].DAC_max);
-            _joint->state = jstate_hard_stop;
-            _joint->current_cmd = 0;
-            stop_trajectory(_joint);
-            log_msg("joint %d checked ",j);
-        }
+		// Check to see if we've reached the joint limit.
+		if( check_homing_condition(_joint) )
+		{
+			log_msg("Found limit on joint %d cmd: %d \t", _joint->type, _joint->current_cmd, DOF_types[_joint->type].DAC_max);
+			_joint->state = jstate_hard_stop;
+			_joint->current_cmd = 0;
+			stop_trajectory(_joint);
+			log_msg("joint %d checked ",j);
+		}
 
-        // For each mechanism, check to see if the mech is finished homing.
-        if ( j == (MAX_DOF_PER_MECH-1) )
-        {
-            /// if we're homing tools, wait for tools to be finished
-            if ((  !tools_ready(_mech) &&
-                   _mech->joint[TOOL_ROT].state==jstate_hard_stop &&
-                   _mech->joint[WRIST   ].state==jstate_hard_stop &&
-                   _mech->joint[GRASP1  ].state==jstate_hard_stop )  // \TODO check for grasp2 - bug?
-                    ||
-                (  tools_ready( _mech ) &&
-                   _mech->joint[SHOULDER].state==jstate_hard_stop &&
-                   _mech->joint[ELBOW   ].state==jstate_hard_stop &&
-                   _mech->joint[Z_INS   ].state==jstate_hard_stop ))
-              {
-                if (delay2==0)
-                    delay2=gTime;
+		// For each mechanism, check to see if the mech is finished homing.
+		if ( j == (MAX_DOF_PER_MECH-1) )
+		{
+			/// if we're homing tools, wait for tools to be finished
+			if ((  !tools_ready(_mech) &&
+					_mech->joint[TOOL_ROT].state==jstate_hard_stop &&
+					_mech->joint[WRIST   ].state==jstate_hard_stop &&
+					_mech->joint[GRASP1  ].state==jstate_hard_stop )  // \TODO check for grasp2 - bug?
+					||
+					(  tools_ready( _mech ) &&
+							_mech->joint[SHOULDER].state==jstate_hard_stop &&
+							_mech->joint[ELBOW   ].state==jstate_hard_stop &&
+							_mech->joint[Z_INS   ].state==jstate_hard_stop ))
+			{
+				if (delay2==0)
+					delay2=gTime;
 
-                if (gTime > delay2 + 200)   // wait 200 ticks for cables to settle down
-                {
-                    set_joints_known_pos(_mech, !tools_ready(_mech) );   // perform second phase
-                    delay2 = 0;
-                }
-            }
-        }
+				if (gTime > delay2 + 200)   // wait 200 ticks for cables to settle down
+				{
+					set_joints_known_pos(_mech, !tools_ready(_mech) );   // perform second phase
+					delay2 = 0;
+				}
+			}
+		}
 
-    }
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
-*   \fn int set_joints_known_pos(mechanism* _mech, int tool_only)
-*
-*	\brief  Set joint angles to known values after hard stops are reached.
-*
-*	\desc Set all the mechanism joints to known reference angles.
-*       Propagate the joint angle to motor position and encoder offset.
-*
-*   \param _mech       which mechanism (gold/green)
-*   \param tool_only   flag which initializes only the tool/wrist joints
-*
-*	\ingroup Control
-*
-*	\return 0
-*
-* 	\todo  Rationalize the sign changes on GREEN_ARM vs GOLD_ARM (see IFDEF below).
-* 	\todo  This MAYBE needs to be changed to support device specific parameter changes read from a config file or ROS service.
-*/
+ *   \fn int set_joints_known_pos(mechanism* _mech, int tool_only)
+ *
+ *	\brief  Set joint angles to known values after hard stops are reached.
+ *
+ *	\desc Set all the mechanism joints to known reference angles.
+ *       Propagate the joint angle to motor position and encoder offset.
+ *
+ *   \param _mech       which mechanism (gold/green)
+ *   \param tool_only   flag which initializes only the tool/wrist joints
+ *
+ *	\ingroup Control
+ *
+ *	\return 0
+ *
+ * 	\todo  Rationalize the sign changes on GREEN_ARM vs GOLD_ARM (see IFDEF below).
+ * 	\todo  This MAYBE needs to be changed to support device specific parameter changes read from a config file or ROS service.
+ */
 int set_joints_known_pos(mechanism* _mech, int tool_only)
 {
-    DOF* _joint=NULL;
-    int j=0;
+	DOF* _joint=NULL;
+	int j=0;
 
-    int scissor = ((_mech->mech_tool.t_end == mopocu_scissor) || (_mech->mech_tool.t_end == potts_scissor))? 1 : 0;
+	int scissor = ((_mech->mech_tool.t_end == mopocu_scissor) || (_mech->mech_tool.t_end == potts_scissor))? 1 : 0;
 
-//    int offset = 0;
-//    if (_mech->type == GREEN_ARM) offset = 8;
-    /// Set joint position reference for just tools, or all DOFS
-    _joint = NULL;
-    while ( loop_over_joints(_mech, _joint ,j) )
-    {
+	log_msg("setting joints known");
 
-    	// when tool joints finish, set positioning joints to neutral
-        if ( tool_only  && ! is_toolDOF( _joint->type))
-        {
-            // Set jpos_d to the joint limit value.
-            _joint->jpos_d = DOF_types[ _joint->type ].home_position;  // keep non tool joints from moving
-        }
+	//    int offset = 0;
+	//    if (_mech->type == GREEN_ARM) offset = 8;
+	/// Set joint position reference for just tools, or all DOFS
+	_joint = NULL;
+	while ( loop_over_joints(_mech, _joint ,j) )
+	{
 
-        // when positioning joints finish, set tool joints to nothing special
-        else if (!tool_only && is_toolDOF(_joint->type) )
-        {
-            _joint->jpos_d = _joint->jpos;
+		// when tool joints finish, set positioning joints to neutral
+		if ( tool_only  && ! is_toolDOF( _joint->type))
+		{
+			// Set jpos_d to the joint limit value.
+			_joint->jpos_d = DOF_types[ _joint->type ].home_position;  // keep non tool joints from moving
+		}
+
+		// when positioning joints finish, set tool joints to nothing special
+		else if (!tool_only && is_toolDOF(_joint->type) )
+		{
+			_joint->jpos_d = _joint->jpos;
 		}
 		// when tool or positioning joints finish, set them to max_angle
 		else {
@@ -276,272 +278,309 @@ int set_joints_known_pos(mechanism* _mech, int tool_only)
 			_joint->state = jstate_homing1;
 		}
 	}
-    /// Inverse cable coupling: jpos_d  ---> mpos_d
-    // use_actual flag triggered for insertion axis
-    invMechCableCoupling(_mech, 1);
+	/// Inverse cable coupling: jpos_d  ---> mpos_d
+	// use_actual flag triggered for insertion axis
+	invMechCableCoupling(_mech, 1);
 
-    _joint = NULL;
-    while ( loop_over_joints(_mech, _joint ,j) )
-    {
-        // Reset the state-estimate filter
-        _joint->mpos = _joint->mpos_d;
-        resetFilter( _joint );
+	_joint = NULL;
+	while ( loop_over_joints(_mech, _joint ,j) )
+	{
+		// Reset the state-estimate filter
+		_joint->mpos = _joint->mpos_d;
+		resetFilter( _joint );
 
-        // Convert the motor position to an encoder offset.
-        // mpos = k * (enc_val - enc_offset)  --->  enc_offset = enc_val - mpos/k
-        float f_enc_val = _joint->enc_val;
+		// Convert the motor position to an encoder offset.
+		// mpos = k * (enc_val - enc_offset)  --->  enc_offset = enc_val - mpos/k
+		float f_enc_val = _joint->enc_val;
+		int j_flip = 1;
 
-        // Encoder values on Gold arm are reversed.  See also state_machine.cpp
-    switch (_mech->mech_tool.t_style){
+		// Encoder values on Gold arm are reversed.  See also state_machine.cpp
+		switch (_mech->mech_tool.t_style){
 		case dv:
 			if ( _mech->type == GOLD_ARM && !is_toolDOF(_joint))
-
+			{
 				f_enc_val *= -1.0;
+			}
+			else if ( _mech->type == GREEN_ARM ){
+				j_flip *= -1.0;
+			}
 			break;
 		case square_raven:
 			if (	( _mech->type == GOLD_ARM && !is_toolDOF(_joint) )
-			    	||
-			    	( _mech->type == GREEN_ARM && is_toolDOF(_joint) ) //Green arm tools are also reversed with square pattern
-			    )
-			    f_enc_val *= -1.0;
+					||
+					( _mech->type == GREEN_ARM && is_toolDOF(_joint) ) //Green arm tools are also reversed with square pattern
+			)
+				f_enc_val *= -1.0;
 			break;
 		default:
 			if ( _mech->type == GOLD_ARM || is_toolDOF(_joint) )
+			{
 				f_enc_val *= -1.0;
+			}
+			if ( _mech->type == GREEN_ARM )
+			{
+				j_flip *= -1.0;
+			}
 			break;
-    }
+		}
 #ifdef OPPOSE_GRIP
-	if (j == GRASP1){
-		f_enc_val *= -1;// switch encoder value for opposed grasp
-//		static int twice = 0;
-//		if (twice < 2){
-//			log_msg("homing enc_val swapped");
-//			twice++;
+		if (j == GRASP1){
+			f_enc_val *= -1;// switch encoder value for opposed grasp
 		}
 #endif
 
+		if (j == Z_INS){
+			j_flip *= -1;
+		}
 
 
-        /// Set the joint offset in encoder space.
-        float cc = ENC_CNTS_PER_REV / (2*M_PI);
-        _joint->enc_offset = f_enc_val - (_joint->mpos_d * cc);
+
+		/// Set the joint offset in encoder space.
+		float cc = ENC_CNTS_PER_REV / (2*M_PI);
+		_joint->enc_offset = f_enc_val - (_joint->mpos_d * cc);
 
 
-        getStateLPF(_joint, _mech->tool_type);
-        //getStateLPF(_joint, _mech->mech_tool.t_style);
-    }
 
-    fwdMechCableCoupling(_mech);
-    return 0;
+		//set the joint encoder offset in encoder space
+		float j_enc_val = j_flip * _joint->joint_enc_val;
+
+		if ((j == SHOULDER)||(j == ELBOW))
+		{ //if joint is shoulder or elbow
+			cc = ROTARY_JOINT_ENC_PER_REV / (2*PI);
+			//log_msg("joint		%d", j);
+			//log_msg("cc value			= %f", cc);
+		}
+		else if (j == Z_INS)
+		{
+			cc = LINEAR_JOINT_ENC_PER_M;
+			//log_msg("joint		%d", j);
+			//log_msg("cc value			= %f", cc);
+		}
+
+		if(!is_toolDOF( _joint->type)){
+			//log_msg("j_enc value			= %f", j_enc_val);
+			//log_msg("j_pos_d				= %f", _joint->jpos_d);
+			//log_msg("j_pos_d*cc				= %f", _joint->jpos_d * cc);
+
+			_joint->joint_enc_offset = j_enc_val - (_joint->jpos_d * cc);
+		}
+
+
+		getStateLPF(_joint, _mech->tool_type);
+		//getStateLPF(_joint, _mech->mech_tool.t_style);
+	}
+
+	fwdMechCableCoupling(_mech);
+	return 0;
 }
 
 /**
-*	\fn void homing(DOF* _joint)
-*
-*	\brief Set trajectory behavior for each joint during the homing process.
-*
-*   \param _joint The joint being controlled.
-*
-* 	\ingroup Control
-*
-*	\return void
-*
-*   \todo  Homing limits should be Amps not DAC units
-*   \todo  Change square vs. diamond to a config-file based runtime system instead of #ifdef
-*/
+ *	\fn void homing(DOF* _joint)
+ *
+ *	\brief Set trajectory behavior for each joint during the homing process.
+ *
+ *   \param _joint The joint being controlled.
+ *
+ * 	\ingroup Control
+ *
+ *	\return void
+ *
+ *   \todo  Homing limits should be Amps not DAC units
+ *   \todo  Change square vs. diamond to a config-file based runtime system instead of #ifdef
+ */
 void homing(DOF* _joint)
 {
-    // duration for homing of each joint
-    const float f_period[MAX_MECH*MAX_DOF_PER_MECH] = {1, 1, 1, 9999999, 1, 1, 1, 1,
-                                                        1, 1, 1, 9999999, 1, 1, 1, 1};
-    // degrees for homing of each joint
+	// duration for homing of each joint
+	const float f_period[MAX_MECH*MAX_DOF_PER_MECH] = {1, 1, 1, 9999999, 1, 1, 1, 1,
+			1, 1, 1, 9999999, 1, 1, 1, 1};
+	// degrees for homing of each joint
 #ifdef RAVEN_II_SQUARE
-    //roll is backwards because of the 'click' in the mechanism
-    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+	//roll is backwards because of the 'click' in the mechanism
+	const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+			-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
 #else
 #ifdef DV_ADAPTER
-    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+		-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
 #else //default
-    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+		-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
 #endif
 #endif
 
 
 
-    switch (_joint->state)
-    {
-        case jstate_wait:
-            break;
+switch (_joint->state)
+{
+case jstate_wait:
+	break;
 
-        case jstate_not_ready:
-            // Initialize velocity trajectory
-            //log_msg("Starting homing on joint %d", _joint->type);
-            _joint->state = jstate_pos_unknown;
-            start_trajectory_mag(_joint, f_magnitude[_joint->type], f_period[_joint->type]);
-            break;
+case jstate_not_ready:
+	// Initialize velocity trajectory
+	//log_msg("Starting homing on joint %d", _joint->type);
+	_joint->state = jstate_pos_unknown;
+	start_trajectory_mag(_joint, f_magnitude[_joint->type], f_period[_joint->type]);
+	break;
 
-        case jstate_pos_unknown:
-            // Set desired joint trajectory
-            update_linear_sinusoid_position_trajectory(_joint);
-            break;
+case jstate_pos_unknown:
+	// Set desired joint trajectory
+	update_linear_sinusoid_position_trajectory(_joint);
+	break;
 
-        case jstate_hard_stop:
-            // Wait for all joints. No trajectory here.
+case jstate_hard_stop:
+	// Wait for all joints. No trajectory here.
 
-            break;
+	break;
 
-        case jstate_homing1:
-            start_trajectory( _joint , DOF_types[_joint->type].home_position, 2.5 );
-            _joint->state = jstate_homing2;
-            break;
+case jstate_homing1:
+	start_trajectory( _joint , DOF_types[_joint->type].home_position, 2.5 );
+	_joint->state = jstate_homing2;
+	break;
 
-        case jstate_homing2:
-            // Move to start position
-            // Update position trajectory
-            if ( !update_position_trajectory(_joint) )
-            {
-                _joint->state = jstate_ready;
-                log_msg("Joint %d ready", _joint->type);
-            }
-            break;
+case jstate_homing2:
+	// Move to start position
+	// Update position trajectory
+	if ( !update_position_trajectory(_joint) )
+	{
+		_joint->state = jstate_ready;
+		log_msg("Joint %d ready", _joint->type);
+	}
+	break;
 
-        default:
-            // not doing joint homing.
-            break;
+default:
+	// not doing joint homing.
+	break;
 
-    } // switch
+} // switch
 
-    return;
+return;
 }
 
 /**
-*	\fn void homing(DOF* _joint, tool a_tool)
-*
-*	\brief Set trajectory behavior for each tool joint during the homing process.
-*
-*   \param _joint The joint being controlled.
-*	\param a_tool The tool being controlled.
-*
-* 	\ingroup Control
-*
-*	\return void
-*   \TODO refactor for tool class
-*/
+ *	\fn void homing(DOF* _joint, tool a_tool)
+ *
+ *	\brief Set trajectory behavior for each tool joint during the homing process.
+ *
+ *   \param _joint The joint being controlled.
+ *	\param a_tool The tool being controlled.
+ *
+ * 	\ingroup Control
+ *
+ *	\return void
+ *   \TODO refactor for tool class
+ */
 void homing(DOF* _joint, tool a_tool)
 {
-    // duration for homing of each joint
-    const float f_period[MAX_MECH*MAX_DOF_PER_MECH] = {1, 1, 1, 9999999, 1, 1, 1, 1,
-                                                        1, 1, 1, 9999999, 1, 1, 1, 1};
-//    // degrees for homing of each joint
-//#ifdef RAVEN_II_SQUARE
-//    //roll is backwards because of the 'click' in the mechanism
-//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
-//#else
-//#ifdef DV_ADAPTER
-//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
-//#else //default
-//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
-//#endif
-//#endif
+	// duration for homing of each joint
+	const float f_period[MAX_MECH*MAX_DOF_PER_MECH] = {1, 1, 1, 9999999, 1, 1, 1, 1,
+			1, 1, 1, 9999999, 1, 1, 1, 1};
+	//    // degrees for homing of each joint
+	//#ifdef RAVEN_II_SQUARE
+	//    //roll is backwards because of the 'click' in the mechanism
+	//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+	//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, -80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+	//#else
+	//#ifdef DV_ADAPTER
+	//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+	//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+	//#else //default
+	//    const float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+	//                                                          -10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+	//#endif
+	//#endif
 
-    //check if scissors
-    int scissor = ((a_tool.t_end == mopocu_scissor) || (a_tool.t_end == potts_scissor))? 1 : 0;
+	//check if scissors
+	int scissor = ((a_tool.t_end == mopocu_scissor) || (a_tool.t_end == potts_scissor))? 1 : 0;
 
-    float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
-    		 	 	 	 	 	 	 	 	 	 	-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
+	float f_magnitude[MAX_MECH*MAX_DOF_PER_MECH] = {-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD,
+			-10 DEG2RAD, 10 DEG2RAD, 0.02, 9999999, 80 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD, 40 DEG2RAD};
 
-    if(a_tool.t_style == square_raven){
-    	if(a_tool.mech_type == GOLD_ARM) f_magnitude[TOOL_ROT_GOLD] =  -80 DEG2RAD;
-    	else if(a_tool.mech_type == GREEN_ARM) f_magnitude[TOOL_ROT_GREEN] =  -80 DEG2RAD;
-    }
-    if (scissor){
-    	if(a_tool.mech_type == GOLD_ARM) f_magnitude[GRASP2_GOLD] = -40 DEG2RAD;
-    	else if(a_tool.mech_type == GREEN_ARM) f_magnitude[GRASP2_GREEN] = -40 DEG2RAD;
-    }
+	if(a_tool.t_style == square_raven){
+		if(a_tool.mech_type == GOLD_ARM) f_magnitude[TOOL_ROT_GOLD] =  -80 DEG2RAD;
+		else if(a_tool.mech_type == GREEN_ARM) f_magnitude[TOOL_ROT_GREEN] =  -80 DEG2RAD;
+	}
+	if (scissor){
+		if(a_tool.mech_type == GOLD_ARM) f_magnitude[GRASP2_GOLD] = -40 DEG2RAD;
+		else if(a_tool.mech_type == GREEN_ARM) f_magnitude[GRASP2_GREEN] = -40 DEG2RAD;
+	}
 
 
-    switch (_joint->state)
-    {
-        case jstate_wait:
-            break;
+	switch (_joint->state)
+	{
+	case jstate_wait:
+		break;
 
-        case jstate_not_ready:
-            // Initialize velocity trajectory
-            //log_msg("Starting homing on joint %d", _joint->type);
-            _joint->state = jstate_pos_unknown;
-            start_trajectory_mag(_joint, f_magnitude[_joint->type], f_period[_joint->type]);
-            break;
+	case jstate_not_ready:
+		// Initialize velocity trajectory
+		//log_msg("Starting homing on joint %d", _joint->type);
+		_joint->state = jstate_pos_unknown;
+		start_trajectory_mag(_joint, f_magnitude[_joint->type], f_period[_joint->type]);
+		break;
 
-        case jstate_pos_unknown:
-            // Set desired joint trajectory
-            update_linear_sinusoid_position_trajectory(_joint);
-            break;
+	case jstate_pos_unknown:
+		// Set desired joint trajectory
+		update_linear_sinusoid_position_trajectory(_joint);
+		break;
 
-        case jstate_hard_stop:
-            // Wait for all joints. No trajectory here.
+	case jstate_hard_stop:
+		// Wait for all joints. No trajectory here.
 
-            break;
+		break;
 
-        case jstate_homing1:
-            start_trajectory( _joint , DOF_types[_joint->type].home_position, 2.5 );
-            _joint->state = jstate_homing2;
-            break;
+	case jstate_homing1:
+		start_trajectory( _joint , DOF_types[_joint->type].home_position, 2.5 );
+		_joint->state = jstate_homing2;
+		break;
 
-        case jstate_homing2:
-            // Move to start position
-            // Update position trajectory
-            if ( !update_position_trajectory(_joint) )
-            {
-                _joint->state = jstate_ready;
-                log_msg("Joint %d ready", _joint->type);
-            }
-            break;
+	case jstate_homing2:
+		// Move to start position
+		// Update position trajectory
+		if ( !update_position_trajectory(_joint) )
+		{
+			_joint->state = jstate_ready;
+			log_msg("Joint %d ready", _joint->type);
+		}
+		break;
 
-        default:
-            // not doing joint homing.
-            break;
+	default:
+		// not doing joint homing.
+		break;
 
-    } // switch
+	} // switch
 
-    return;
+	return;
 }
 
 // \TODO move to more appropriate location
 #ifdef RAVEN_II_SQUARE
 // RII_Square has higher limits on tool b/c there's more friction
 const int homing_max_dac[8] = {2500,  //shoulder
-                            2500,  //elbow
-                            1200,  //z-ins
-                            0,
-                            2800,  //tool_rot // was 1400, lowered to reduce calibration error //I think this is labeled improperly - AL
-                            2200,  //wrist
-                            2300,  //grasp1
-                            2300};  // grasp2
+		2500,  //elbow
+		1200,  //z-ins
+		0,
+		2800,  //tool_rot // was 1400, lowered to reduce calibration error //I think this is labeled improperly - AL
+		2200,  //wrist
+		2300,  //grasp1
+		2300};  // grasp2
 #else
 #ifdef DV_ADAPTER
 const int homing_max_dac[8] = {2500,  //shoulder
-                            2500,  //elbow
-                            1400,  //z-ins
-                            0,
-                            2000,  //tool_rot // was 1400, lowered to reduce calibration error //I think this is labeled improperly - AL
-                            2400,  //wrist
-                            2000,  //grasp1
-                            2000};  // grasp2
+		2500,  //elbow
+		1400,  //z-ins
+		0,
+		2000,  //tool_rot // was 1400, lowered to reduce calibration error //I think this is labeled improperly - AL
+		2400,  //wrist
+		2000,  //grasp1
+		2000};  // grasp2
 #else
-const int homing_max_dac[8] = {2500,  //shoulder
-                            2500,  //elbow
-                            2100, //1900,  //z_ins
-                            0,
-                            1900,  //tool_rot  //rasised from 1400 alewis 3/4/14
-                            1900,  //wrist
-                            1900,  //grasp1 decreased from 1900
-                            1900};  // grasp2 decreased from 1900
+const int homing_max_dac[8] = {2100,  //shoulder
+		2100,  //elbow
+		1600, //1900,  //z_ins
+		0,
+		1900,  //tool_rot  //rasised from 1400 alewis 3/4/14
+		1900,  //wrist
+		1900,  //grasp1 decreased from 1900
+		1900};  // grasp2 decreased from 1900
 #endif
 #endif
 
@@ -565,17 +604,17 @@ const int homing_max_dac[8] = {2500,  //shoulder
  */
 int check_homing_condition(DOF *_joint)
 {
-    if ( _joint->state != jstate_pos_unknown)
-        return 0;
+	if ( _joint->state != jstate_pos_unknown)
+		return 0;
 
-    // check if the DAC output is greater than the maximum allowable.
-    // Note, current_cmd is an integer, so using abs (not fabs) is okay.
-    if( abs(_joint->current_cmd) >= homing_max_dac[_joint->type%8]  )
-    {
-        return 1;
-    }
+	// check if the DAC output is greater than the maximum allowable.
+	// Note, current_cmd is an integer, so using abs (not fabs) is okay.
+	if( abs(_joint->current_cmd) >= homing_max_dac[_joint->type%8]  )
+	{
+		return 1;
+	}
 
-   return 0;
+	return 0;
 }
 
 

--- a/src/raven/homing.cpp
+++ b/src/raven/homing.cpp
@@ -62,10 +62,10 @@
 
 int set_joints_known_pos(mechanism* _mech, int tool_only);
 
-extern int NUM_MECH;
+
 extern unsigned long int gTime;
 extern DOF_type DOF_types[];
-extern unsigned int soft_estopped;
+
 
 /**
 *   \fn int raven_homing(device *device0, param_pass *currParams, int begin_homing)
@@ -536,7 +536,7 @@ const int homing_max_dac[8] = {2500,  //shoulder
 #else
 const int homing_max_dac[8] = {2500,  //shoulder
                             2500,  //elbow
-                            2600, //1900,  //z_ins
+                            2100, //1900,  //z_ins
                             0,
                             1900,  //tool_rot  //rasised from 1400 alewis 3/4/14
                             1900,  //wrist

--- a/src/raven/init.cpp
+++ b/src/raven/init.cpp
@@ -235,12 +235,9 @@ void initDOFs(device *device0)
 
         device0->mech[i].tool_type = use_tool;
 
-        log_msg("tool type %i", device0->mech[i].tool_type);
-
         /// Initialize joint types
         if ( device0->mech[i].type == GOLD_ARM)
         {
-            log_msg("    Initing gold arm");
             //Set DOF type to unique index
             device0->mech[i].joint[SHOULDER].type = SHOULDER_GOLD;
             device0->mech[i].joint[ELBOW].type    = ELBOW_GOLD;
@@ -255,7 +252,6 @@ void initDOFs(device *device0)
         }
         else if (device0->mech[i].type == GREEN_ARM)
         {
-            log_msg("    Initing green arm");
             device0->mech[i].joint[SHOULDER].type = SHOULDER_GREEN;
             device0->mech[i].joint[ELBOW].type    = ELBOW_GREEN;
             device0->mech[i].joint[Z_INS].type    = Z_INS_GREEN;

--- a/src/raven/init.cpp
+++ b/src/raven/init.cpp
@@ -373,18 +373,27 @@ void initDOFs(device *device0)
         }
 
         /// Set the encoder offset from Kinematic Zero
-        //   Note: enc_offset initialized first above
+        //  Note: enc_offset initialized first above
+        //	Note: all evaluate to 0.0;
         if ( device0->mech[i].type == GOLD_ARM)
         {
             device0->mech[i].joint[SHOULDER].enc_offset += SHOULDER_GOLD_KIN_OFFSET * ENC_CNT_PER_DEG * DOF_types[SHOULDER_GOLD].TR; // Degrees * enc/degree *
             device0->mech[i].joint[ELBOW].enc_offset    += ELBOW_GOLD_KIN_OFFSET    * ENC_CNT_PER_DEG * DOF_types[ELBOW_GOLD].TR;
             device0->mech[i].joint[Z_INS].enc_offset    += Z_INS_GOLD_KIN_OFFSET    * DOF_types[Z_INS_GOLD].TR * ENC_CNT_PER_RAD;  // use enc/rad because conversion from meters to revolutions is in radians
+
+            device0->mech[i].joint[SHOULDER].joint_enc_offset += SHOULDER_GOLD_KIN_OFFSET * JOINT_ENC_CNT_PER_DEG; // Degrees * enc/degree *
+            device0->mech[i].joint[ELBOW].joint_enc_offset    += ELBOW_GOLD_KIN_OFFSET    * JOINT_ENC_CNT_PER_DEG;
+            device0->mech[i].joint[Z_INS].joint_enc_offset    += Z_INS_GOLD_KIN_OFFSET    * LINEAR_JOINT_ENC_PER_M;  // use enc/rad because conversion from meters to revolutions is in radians
         }
         else if (device0->mech[i].type == GREEN_ARM)
         {
             device0->mech[i].joint[SHOULDER].enc_offset += SHOULDER_GREEN_KIN_OFFSET * ENC_CNT_PER_DEG * DOF_types[SHOULDER_GREEN].TR;
             device0->mech[i].joint[ELBOW].enc_offset    += ELBOW_GREEN_KIN_OFFSET    * ENC_CNT_PER_DEG * DOF_types[ELBOW_GREEN].TR;
             device0->mech[i].joint[Z_INS].enc_offset    += Z_INS_GREEN_KIN_OFFSET    * DOF_types[Z_INS_GREEN].TR * ENC_CNT_PER_RAD;  // use enc/rad because conversion from meters to revolutions is in radians
+
+            device0->mech[i].joint[SHOULDER].joint_enc_offset += SHOULDER_GREEN_KIN_OFFSET * JOINT_ENC_CNT_PER_DEG; // Degrees * enc/degree *
+            device0->mech[i].joint[ELBOW].joint_enc_offset    += ELBOW_GREEN_KIN_OFFSET    * JOINT_ENC_CNT_PER_DEG;
+            device0->mech[i].joint[Z_INS].joint_enc_offset    += Z_INS_GREEN_KIN_OFFSET    * LINEAR_JOINT_ENC_PER_M;  // use enc/rad because conversion from meters to revolutions is in radians
         }
 
         /// Initialize some more mechanism stuff

--- a/src/raven/init.cpp
+++ b/src/raven/init.cpp
@@ -555,6 +555,8 @@ int init_ravengains(ros::NodeHandle n, device *device0)
             DOF_types[14].KP, DOF_types[14].KD, DOF_types[14].KI,
             DOF_types[15].KP, DOF_types[15].KD, DOF_types[15].KI);
     }
+
+
     return 0;
 }
 

--- a/src/raven/network_layer.cpp
+++ b/src/raven/network_layer.cpp
@@ -177,7 +177,7 @@ void* network_process(void* param1)
 
     // print some status messages
     log_msg("Starting network services...");
-    log_msg("  u_struct size: %i",uSize);
+    //log_msg("  u_struct size: %i",uSize);
     log_msg("  Using default port %s",port);
 
     ///// open log file

--- a/src/raven/network_layer.cpp
+++ b/src/raven/network_layer.cpp
@@ -184,7 +184,7 @@ void* network_process(void* param1)
     logFile = open("err_network.log", O_WRONLY | O_CREAT | O_APPEND  | O_NONBLOCK , 0664);
     if ( logFile < 0 )
     {
-        ROS_ERROR("ERROR: could not open log file.\n");
+        ROS_ERROR("ERROR: could not open log file. %d -- %s\n", logFile, std::strerror(errno));
         exit(1);
     }
     gettimeofday(&tv,&tz);

--- a/src/raven/put_USB_packet.cpp
+++ b/src/raven/put_USB_packet.cpp
@@ -112,10 +112,10 @@ int putUSBPacket(int id, mechanism *mech)
 }
 
 /**\fn int putJointEncUSBPacket(int id)
-  \brief sends empty packet to specified Joint Enc board
+  \brief 		sends empty packet to specified Joint Enc board
 
-  \param id the usb board id number (serial#)
-  \return success of the operation
+  \param id 	the usb board id number (serial#)
+  \return 		success of the operation
   \ingroup Network
  */
 int putJointEncUSBPacket(int id)
@@ -131,7 +131,6 @@ int putJointEncUSBPacket(int id)
 		buffer_out[2*i+2] = (char) DAC_OFFSET;
 		buffer_out[2*i+3] = (char) (DAC_OFFSET >> 8);
 
-		//Remove offset
 	}
 
 	// Set PortF outputs to zero

--- a/src/raven/r2_kinematics.cpp
+++ b/src/raven/r2_kinematics.cpp
@@ -1025,11 +1025,6 @@ void theta2joint(ik_solution in_iktheta, double *out_J)
 		out_J[4] = in_iktheta.th5 - TH5_J4_R * d2r;
 		out_J[5] = in_iktheta.th6 - TH6A_J5_R * d2r;
 
-		static int arm_check = 0;
-		if (arm_check < 2) {
-			log_msg("definitely the right arm -- t2j");
-			arm_check++;
-		}
 	}
 
 	// bring to range {-pi , pi}

--- a/src/raven/rt_process_preempt.cpp
+++ b/src/raven/rt_process_preempt.cpp
@@ -199,7 +199,7 @@ static void *rt_process(void* )
   tsnorm(&t);
   clock_nanosleep(0, TIMER_ABSTIME, &t, NULL);
 
-  log_msg("*** Ready to teleoperate ***");
+
 
 
 

--- a/src/raven/rt_raven.cpp
+++ b/src/raven/rt_raven.cpp
@@ -164,6 +164,7 @@ int controlRaven(device *device0, param_pass *currParams){
             {
                 currParams->robotControlMode = cartesian_space_control;
                 newRobotControlMode = cartesian_space_control;
+                log_msg("*** Ready to teleoperate ***");
             }
             break;
 	//Runs applyTorque() to set torque command (tau_d) to a joint for debugging purposes

--- a/src/raven/rt_raven.cpp
+++ b/src/raven/rt_raven.cpp
@@ -103,8 +103,13 @@ int controlRaven(device *device0, param_pass *currParams){
     //Compute Mpos & Velocities
     stateEstimate(device0);
 
-    //Foward Cable Coupling
+    //Forward Cable Coupling
     fwdCableCoupling(device0, currParams->runlevel);
+
+    //Calculate joint positions from joint encoders
+    if(JOINT_ENCODERS){
+    	fwdJointEncoders(device0);
+    }
 
     //Forward kinematics
     r2_fwd_kin(device0, currParams->runlevel);


### PR DESCRIPTION
A third USB board can be specified and opened to read three joint encoders on each arm. These are specifically set up for systems made by Applied Dexterity in Spring 18, but should be compatible with future joint encoder packages. Testing was carried out at UVA in March 2018.