### PR TITLE
add transport hint to automove subscription

### DIFF
--- a/src/raven/local_io.cpp
+++ b/src/raven/local_io.cpp
@@ -369,7 +369,8 @@ int init_ravenstate_publishing(ros::NodeHandle &n) {
   joint_publisher = n.advertise<sensor_msgs::JointState>("joint_states", 1);
 
   sub_automove = n.subscribe<raven_automove>("raven_automove", 1, autoincrCallback,
-                                             ros::TransportHints().unreliable());
+                                             ros::TransportHints().unreliable()
+                                                                  .reliable());
 
   return 0;
 }


### PR DESCRIPTION
Rospy does not support unreliable (i.e. UDP) transport hints, so the callback does not get triggered. The subscriber will now try reliable (TCP?) connection if unreliable is not working.